### PR TITLE
Add KTB statistics charts and responsive filter

### DIFF
--- a/index.php
+++ b/index.php
@@ -103,6 +103,26 @@ function save_user($user) {
   if (!$found) $users[] = $user;
   db_save('users',$users);
 }
+function delete_user($username) {
+  $users = db_read('users');
+  $users = array_values(array_filter($users, fn($u)=>strcasecmp($u['username'] ?? '', $username)!==0));
+  db_save('users',$users);
+
+  $m = db_read('memberships');
+  $m = array_values(array_filter($m, fn($r)=>strcasecmp($r['username'] ?? '', $username)!==0));
+  db_save('memberships',$m);
+
+  $att = db_read('attendance');
+  $att = array_values(array_filter($att, fn($a)=>strcasecmp($a['username'] ?? '', $username)!==0));
+  db_save('attendance',$att);
+
+  $ktbs = db_read('ktb_groups');
+  $changed=false;
+  foreach ($ktbs as &$k) {
+    if (isset($k['leader']) && strcasecmp($k['leader'],$username)===0) { $k['leader']=''; $changed=true; }
+  }
+  if ($changed) db_save('ktb_groups',$ktbs);
+}
 function user_exists($username) { return get_user($username) !== null; }
 
 function get_campus($id) {
@@ -480,6 +500,17 @@ if (is_logged_in()) {
     header('Location:?action=users'); exit;
   }
 
+  if ($action==='user_delete' && $_SERVER['REQUEST_METHOD']==='POST' && is_admin()) {
+    if (!csrf_ok($_POST['csrf'] ?? '')) die('CSRF invalid');
+    $uname = $_POST['username'] ?? '';
+    if ($uname !== '') {
+      delete_user($uname);
+      if (isset($_SESSION['user']) && strcasecmp($_SESSION['user']['username'],$uname)===0) unset($_SESSION['user']);
+      $msg='Pengguna dihapus.';
+    }
+    header('Location:?action=users'); exit;
+  }
+
   // KTB ADD (ADMIN ATAU USER BIASA -> otomatis leader)
   if ($action==='ktb_add' && $_SERVER['REQUEST_METHOD']==='POST') {
     if (!csrf_ok($_POST['csrf'] ?? '')) die('CSRF invalid');
@@ -724,6 +755,20 @@ function layout_header($title) {
   .status-cancelled{color:#ff5d6c}
   img.thumb{max-width:120px;border-radius:8px;border:1px solid #2a3b76}
 
+  .filter-inline{display:flex;flex-wrap:wrap;gap:8px;align-items:flex-end}
+  .filter-inline div{flex:0 0 auto}
+  .filter-inline input,.filter-inline select{width:auto}
+  @media(max-width:600px){
+    .filter-inline{flex-direction:column}
+    .filter-inline div{width:100%}
+    .filter-inline input,.filter-inline select{width:100%}
+  }
+
+  .chart-row{display:flex;flex-wrap:wrap;gap:16px}
+  .chart-row .card{flex:1 1 260px}
+  .chart-row canvas{max-width:100%;height:auto}
+  @media(max-width:600px){.chart-row{flex-direction:column}}
+
   /* Tabel responsive via wrapper */
   .table-wrap{width:100%;overflow-x:auto}
   table{width:100%;border-collapse:collapse;min-width:720px}
@@ -751,6 +796,7 @@ function layout_header($title) {
     if (is_admin()) {
       echo '<a href="?action=campuses" title="Kampus/Unit">Kampus</a>';
       echo '<a href="?action=users" title="Pengguna">Users</a>';
+      echo '<a href="?action=analysis" title="Analisis Data">Analisis</a>';
     }
     echo '<a href="?action=ktb" title="Kelola KTB">KTB</a>';
     echo '<a href="?action=my" title="Profil Saya">Saya</a>';
@@ -816,6 +862,138 @@ if ($action==='dashboard') {
 }
 function card_stat($label,$value){
   return '<div class="card"><div class="muted">'.$label.'</div><div style="font-size:2rem;font-weight:800">'.e($value).'</div></div>';
+}
+
+// ANALYSIS (admin)
+if ($action==='analysis') {
+  if (!is_admin()) { header('Location:?action=dashboard'); exit; }
+
+  layout_header('Analisis Data');
+
+  // filters
+  $campus_id = $_GET['campus_id'] ?? '';
+  $angkatan  = $_GET['angkatan'] ?? '';
+  $start     = $_GET['start'] ?? '';
+  $end       = $_GET['end'] ?? '';
+
+  $campuses = db_read('campuses');
+  $users    = db_read('users');
+  $meetings     = db_read('meetings');
+  $ktb          = db_read('ktb_groups');
+  $memberships  = db_read('memberships');
+
+  // maps for quick lookup
+  $ktbMap  = []; foreach ($ktb as $k) $ktbMap[$k['id']] = $k;
+  $userMap = []; foreach ($users as $u) $userMap[strtolower($u['username'])] = $u;
+
+  // map each KTB to its leader's angkatan
+  $ktbLeaderAng = [];
+  foreach ($memberships as $m) {
+    if (($m['role'] ?? '') !== 'leader') continue;
+    $u = $userMap[strtolower($m['username'])] ?? null;
+    if ($u) $ktbLeaderAng[$m['ktb_id']] = $u['angkatan'] ?? '';
+  }
+  $angkatanOpts = array_unique(array_filter(array_values($ktbLeaderAng)));
+  sort($angkatanOpts);
+
+  // summary counts for KTB, unique leaders, and members
+  $ktbCount = 0;
+  foreach ($ktb as $k) {
+    if ($campus_id && (($k['campus_id'] ?? '') !== $campus_id)) continue;
+    if ($angkatan && (($ktbLeaderAng[$k['id']] ?? '') !== $angkatan)) continue;
+    $ktbCount++;
+  }
+  $uniqueUsers = [];
+  $uniqueLeaders = [];
+  foreach ($memberships as $m) {
+    $kt = $ktbMap[$m['ktb_id']] ?? null;
+    if (!$kt) continue;
+    if ($campus_id && (($kt['campus_id'] ?? '') !== $campus_id)) continue;
+    if ($angkatan && (($ktbLeaderAng[$m['ktb_id']] ?? '') !== $angkatan)) continue;
+    $u = $userMap[strtolower($m['username'])] ?? null;
+    if (!$u) continue;
+    $un = strtolower($m['username']);
+    $uniqueUsers[$un] = true;
+    if (($m['role'] ?? '') === 'leader') $uniqueLeaders[$un] = true;
+  }
+  $leaderCount = count($uniqueLeaders);
+  $memberCount = max(0, count($uniqueUsers) - $leaderCount);
+
+  // meeting counts per KTB for pie chart
+  $meetingCounts = [];
+  foreach ($meetings as $m) {
+    if ($start && ($m['date'] ?? '') < $start) continue;
+    if ($end && ($m['date'] ?? '') > $end) continue;
+    $kt = $ktbMap[$m['ktb_id']] ?? null;
+    if (!$kt) continue;
+    if ($campus_id && (($kt['campus_id'] ?? '') !== $campus_id)) continue;
+    if ($angkatan && (($ktbLeaderAng[$m['ktb_id']] ?? '') !== $angkatan)) continue;
+    $name = $kt['name'] ?? ('KTB '.$m['ktb_id']);
+    if (!isset($meetingCounts[$name])) $meetingCounts[$name] = 0;
+    $meetingCounts[$name]++;
+  }
+  $meetingTotal = array_sum($meetingCounts);
+
+  // Filter form
+  echo '<div class="card"><h3>Filter</h3><form method="get" action="" class="filter-inline">';
+  echo '<input type="hidden" name="action" value="analysis">';
+  echo '<div><label>Kampus</label><select name="campus_id"><option value="">-- Semua --</option>';
+  foreach ($campuses as $c) {
+    $sel = $campus_id === ($c['id'] ?? '') ? 'selected' : '';
+    echo '<option value="'.e($c['id']).'" '.$sel.'>'.e($c['name']).'</option>';
+  }
+  echo '</select></div>';
+  echo '<div><label>Angkatan</label><select name="angkatan"><option value="">-- Semua --</option>';
+  foreach ($angkatanOpts as $ang) {
+    $sel = $angkatan === $ang ? 'selected' : '';
+    echo '<option value="'.e($ang).'" '.$sel.'>'.e($ang).'</option>';
+  }
+  echo '</select></div>';
+  echo '<div><label>Dari Tanggal</label><input type="date" name="start" value="'.e($start).'"></div>';
+  echo '<div><label>Sampai Tanggal</label><input type="date" name="end" value="'.e($end).'"></div>';
+  echo '<div class="mt8"><button class="btn-icon" title="Terapkan">Terapkan</button></div>';
+  echo '</form></div>';
+
+  echo '<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>';
+
+  echo '<div class="chart-row">';
+
+  echo '<div class="card"><h3>Statistik KTB</h3>';
+  $sumAll = $ktbCount + $leaderCount + $memberCount + $meetingTotal;
+  if ($sumAll === 0) {
+    echo '<div class="muted">Belum ada data untuk filter ini.</div>';
+  } else {
+    echo '<canvas id="chartKTB" width="300" height="220"></canvas>';
+    echo '<ul>';
+    echo '<li>Jumlah KTB: '.e($ktbCount).'</li>';
+    echo '<li>Jumlah Pemimpin: '.e($leaderCount).'</li>';
+    echo '<li>Jumlah Adek: '.e($memberCount).'</li>';
+    echo '<li>Jumlah Pertemuan: '.e($meetingTotal).'</li>';
+    echo '</ul>';
+    echo '<script>const ctxK=document.getElementById("chartKTB").getContext("2d");new Chart(ctxK,{type:"bar",data:{labels:["KTB","Pemimpin","Adek","Pertemuan"],datasets:[{data:['.$ktbCount.','.$leaderCount.','.$memberCount.','.$meetingTotal.'],backgroundColor:["#2196f3","#9c27b0","#ffc107","#4caf50"]}]},options:{plugins:{legend:{display:false}}}});</script>';
+  }
+  echo '</div>';
+
+  echo '<div class="card"><h3>Ringkasan Pertemuan</h3>';
+  if (!$meetingCounts) {
+    echo '<div class="muted">Belum ada data untuk filter ini.</div>';
+  } else {
+    $labels = array_map('e', array_keys($meetingCounts));
+    $dataVals = array_values($meetingCounts);
+    $colors = [];
+    $countLabels = count($labels);
+    for ($i=0;$i<$countLabels;$i++) $colors[] = 'hsl('.(360*$i/$countLabels).',70%,60%)';
+    echo '<canvas id="chartMeeting" width="300" height="220"></canvas>';
+    echo '<ul>';
+    foreach ($meetingCounts as $k=>$v) echo '<li>'.e($k).': '.e($v).'</li>';
+    echo '</ul>';
+    echo '<script>const ctxM=document.getElementById("chartMeeting").getContext("2d");new Chart(ctxM,{type:"pie",data:{labels:["'.implode('","',$labels).'"],datasets:[{data:['.implode(',', $dataVals).'],backgroundColor:["'.implode('","',$colors).'"]}]}});</script>';
+  }
+  echo '</div>';
+
+  echo '</div>';
+
+  layout_footer(); exit;
 }
 
 // CAMPUSES (admin)
@@ -1000,11 +1178,16 @@ if ($action==='users') {
               <div class="mt8">
                 <label>Password baru</label>
                 <input type="text" name="newpw" value="12345678" style="max-width:160px" placeholder="PW baru">
-                <button class="btn-ghost" title="Reset password" type="submit" formaction="?action=user_resetpw">Reset</button>
-              </div>
+              <button class="btn-ghost" title="Reset password" type="submit" formaction="?action=user_resetpw">Reset</button>
+            </div>
 
             </form>
           </details>
+          <form method="post" action="?action=user_delete" style="display:inline" onsubmit="return confirm(\'Hapus?\')">
+            <input type="hidden" name="csrf" value="'.e($csrf).'">
+            <input type="hidden" name="username" value="'.$unameSafe.'">
+            <button class="btn-danger" title="Hapus">Hapus</button>
+          </form>
         </td>
       </tr>';
     }


### PR DESCRIPTION
## Summary
- Count unique leaders and derive member totals for accurate KTB statistics
- Show per-KTB meeting counts alongside bar chart with responsive flex layout
- Replace attendance totals with meeting counts and shrink charts for side-by-side display
- Filter angkatan based on KTB leader year to avoid member-year misclassification
- Allow admins to delete users and remove related data

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a356d778b0832b92f508cc18ca07e5