### PR TITLE
Hide analysis filter parameters in URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -905,10 +905,10 @@ if ($action==='analysis') {
   layout_header('Analisis Data');
 
   // filters
-  $campus_id = $_GET['campus_id'] ?? '';
-  $angkatan  = $_GET['angkatan'] ?? '';
-  $start     = $_GET['start'] ?? '';
-  $end       = $_GET['end'] ?? '';
+  $campus_id = $_POST['campus_id'] ?? '';
+  $angkatan  = $_POST['angkatan'] ?? '';
+  $start     = $_POST['start'] ?? '';
+  $end       = $_POST['end'] ?? '';
 
   $campuses = db_read('campuses');
   $users    = db_read('users');
@@ -969,8 +969,7 @@ if ($action==='analysis') {
   $meetingTotal = array_sum($meetingCounts);
 
   // Filter form
-  echo '<div class="card"><h3>Filter</h3><form method="get" action="" class="filter-inline">';
-  echo '<input type="hidden" name="action" value="analysis">';
+  echo '<div class="card"><h3>Filter</h3><form method="post" action="" class="filter-inline">';
   echo '<div><label>Kampus</label><select name="campus_id"><option value="">-- Semua --</option>';
   foreach ($campuses as $c) {
     $sel = $campus_id === ($c['id'] ?? '') ? 'selected' : '';
@@ -986,7 +985,7 @@ if ($action==='analysis') {
   echo '<div><label>Dari Tanggal</label><input type="date" name="start" value="'.e($start).'"></div>';
   echo '<div><label>Sampai Tanggal</label><input type="date" name="end" value="'.e($end).'"></div>';
   echo '</form></div>';
-  echo '<script>document.querySelectorAll(".filter-inline input,.filter-inline select").forEach(el=>el.addEventListener("change",()=>el.form.submit()));</script>';
+  echo '<script>document.querySelectorAll(".filter-inline input,.filter-inline select").forEach(el=>el.addEventListener("change",()=>el.form.dispatchEvent(new Event("submit",{bubbles:true,cancelable:true}))));</script>';
 
   echo '<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>';
 


### PR DESCRIPTION
## Summary
- Switch analysis filter form to POST and read filter inputs from `$_POST`
- Dispatch filter submissions via `submit` event to avoid showing query links

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a42f6e70f0832b9119fd971e4c97c5